### PR TITLE
Specify the version of Twisted

### DIFF
--- a/hacker-notebook/Dockerfile
+++ b/hacker-notebook/Dockerfile
@@ -51,7 +51,7 @@ RUN pip install pyopenssl service_identity Twisted==18.9.0 && \
 COPY --chown=1000:100 Hacker.ipynb $HOME/
 COPY --chown=1000:100 SSLStrip.ipynb $HOME/
 
-
+WORKDIR $HOME
 
 CMD ["start-notebook.sh","--NotebookApp.token="]
 

--- a/hacker-notebook/Dockerfile
+++ b/hacker-notebook/Dockerfile
@@ -7,13 +7,13 @@ USER root
 # Install the necessary networking tools
 RUN apt-get update && \
     apt-get install -yq --no-install-recommends \
-    gcc \
+    gcc=4:7.4.0-1ubuntu2.3 \
     libc-dev \
-    dsniff \
-    inetutils-ping \
-    inetutils-traceroute \
-    net-tools \
-    iptables \
+    dsniff=2.4b1+debian-28.1~build1 \
+    inetutils-ping=2:1.9.4-3 \
+    inetutils-traceroute=2:1.9.4-3 \
+    net-tools=1.60+git20161116.90da8a0-1ubuntu1 \
+    iptables=1.6.1-2ubuntu2 \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
@@ -25,7 +25,7 @@ RUN chmod 0400 /etc/sudoers.d/hackersudo
 # Create a Python 2.x environment using conda including at least the ipython kernel
 # and the kernda utility. Add any additional packages you want available for use
 # in a Python 2 notebook to the first line here (e.g., pandas, matplotlib, etc.)
-RUN conda create --quiet --yes -p $CONDA_DIR/envs/python2 python=2.7 ipython ipykernel kernda && \
+RUN conda create --quiet --yes -p $CONDA_DIR/envs/python2 python=2.7 ipython=5.8.0 ipykernel=4.10.0 kernda=0.3.0 && \
     conda clean -tipsy
 
 # Create a global kernelspec in the image and modify it so that it properly activates
@@ -42,7 +42,7 @@ COPY sslstrip /tmp
 WORKDIR /tmp
 
 # Install SSLStrip and its dependencies
-RUN pip install pyopenssl service_identity Twisted==18.9.0 && \
+RUN pip install pyopenssl==19.0.0 service_identity==18.1.0 Twisted==18.9.0 && \
     python setup.py install && \
     rm -rf /tmp/sslstrip && \
     fix-permissions $CONDA_DIR

--- a/hacker-notebook/Dockerfile
+++ b/hacker-notebook/Dockerfile
@@ -42,7 +42,7 @@ COPY sslstrip /tmp
 WORKDIR /tmp
 
 # Install SSLStrip and its dependencies
-RUN pip install pyopenssl service_identity Twisted && \
+RUN pip install pyopenssl service_identity Twisted==18.9.0 && \
     python setup.py install && \
     rm -rf /tmp/sslstrip && \
     fix-permissions $CONDA_DIR
@@ -51,7 +51,7 @@ RUN pip install pyopenssl service_identity Twisted && \
 COPY --chown=1000:100 Hacker.ipynb $HOME/
 COPY --chown=1000:100 SSLStrip.ipynb $HOME/
 
-WORKDIR $HOME
+
 
 CMD ["start-notebook.sh","--NotebookApp.token="]
 

--- a/hacker-notebook/hackersudo
+++ b/hacker-notebook/hackersudo
@@ -1,3 +1,4 @@
 jovyan ALL=(root) NOPASSWD: /usr/sbin/arpspoof
 jovyan ALL=(root) NOPASSWD: /sbin/iptables
 
+

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -10,19 +10,19 @@ USER root
 # Install Apache2
 RUN apt-get update && \
     apt-get install -y \
-	apache2 \
-	apache2-utils \
-	libapache2-mod-wsgi-py3 \
-	ssl-cert \
-	net-tools \
-	supervisor
+	apache2=2.4.29-1ubuntu4.6 \
+	apache2-utils=2.4.29-1ubuntu4.6 \
+	libapache2-mod-wsgi-py3=4.5.17-1 \
+	ssl-cert=1.0.39 \
+	net-tools=1.60+git20161116.90da8a0-1ubuntu1 \
+	supervisor=3.3.1-1.1
 
 # Create the default directory
 RUN mkdir -p /srv/www/app
 
 # Clone the app and install packages
 ADD app /srv/www/app
-RUN pip install Flask
+RUN pip install Flask==1.0.3
 
 #copy conf files for our new app over to Apache's conf
 ADD conf /etc/apache2/sites-available

--- a/server/server
+++ b/server/server
@@ -2,7 +2,7 @@
 
 case "$1" in
     up)
-	kubectl run --image rkalyana/arpspoof-server --port 3000 arpspoof-server
+	kubectl run --image rkalyana/arpspoof-server --port 8888 arpspoof-server
 	kubectl expose deployment arpspoof-server --type NodePort
 	;;
     down)

--- a/victim-vnc/Dockerfile
+++ b/victim-vnc/Dockerfile
@@ -3,7 +3,7 @@ FROM dorowu/ubuntu-desktop-lxde-vnc:bionic
 MAINTAINER Rajesh Kalyanam "rkalyanapurdue@gmail.com"
 
 #add utilities to run ping and traceroute
-RUN apt-get update && apt-get -y install inetutils-ping inetutils-traceroute
+RUN apt-get update && apt-get -y install inetutils-ping=2:1.9.4-3 inetutils-traceroute=2:1.9.4-3
 
 #create a non-root user
 RUN useradd -d /home/victim -m -s /bin/bash victim


### PR DESCRIPTION
Specify the version of Twisted (set to 18.2.0) to avoid potential exceptions thrown by sslstrip.py (Twisted 19.2.0 raises exceptions.AttributeError: 'int' object has no attribute 'splitlines')